### PR TITLE
Add OpenVINO based bilingual translator prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Bilingual Live Translator
+
+This prototype demonstrates a simple bilingual speech translator that uses **OpenVINO**
+for both speech recognition and machine translation.  It follows the features
+described in the [requirement definition](Requirment_Definition.md).
+
+## Features
+- Speech-to-text using Whisper converted for OpenVINO.
+- English ⇄ Japanese translation with MarianMT models accelerated by OpenVINO.
+- Color coded console output (blue/green for original text, magenta/cyan for translation).
+
+## Usage
+Install dependencies (requires internet access):
+```bash
+pip install -r requirements.txt
+```
+
+Translate text:
+```bash
+python app.py --text "Hello" --source en --target ja
+```
+
+Transcribe and translate an audio file:
+```bash
+python app.py --audio path/to/audio.wav --source ja --target en
+```
+
+Both commands print the original and translated text with colors for easy distinction.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,98 @@
+import argparse
+from dataclasses import dataclass
+from typing import Tuple
+
+from colorama import Fore, Style
+
+try:
+    from openvino_whisper import WhisperModel
+    from optimum.intel import OVModelForSeq2SeqLM
+    from transformers import AutoTokenizer
+except ImportError:
+    WhisperModel = OVModelForSeq2SeqLM = AutoTokenizer = None  # type: ignore
+
+
+@dataclass
+class TranslationPair:
+    text: str
+    translation: str
+
+
+class BilingualLiveTranslator:
+    """Simple bilingual translator using OpenVINO for inference."""
+
+    def __init__(self, device: str = "CPU"):
+        if WhisperModel is None or OVModelForSeq2SeqLM is None:
+            raise RuntimeError("Required packages are not installed. See requirements.txt")
+        # Load Whisper for speech recognition
+        self.whisper = WhisperModel("tiny", device=device)
+        # Load translation models
+        self.en_ja_tok = AutoTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-ja")
+        self.en_ja_model = OVModelForSeq2SeqLM.from_pretrained("Helsinki-NLP/opus-mt-en-ja")
+        self.ja_en_tok = AutoTokenizer.from_pretrained("Helsinki-NLP/opus-mt-ja-en")
+        self.ja_en_model = OVModelForSeq2SeqLM.from_pretrained("Helsinki-NLP/opus-mt-ja-en")
+
+    def transcribe(self, audio_path: str, language: str) -> str:
+        """Transcribe audio using Whisper.
+
+        Parameters
+        ----------
+        audio_path: str
+            Path to audio file.
+        language: str
+            Source language code ("en" or "ja").
+        """
+        result = self.whisper.transcribe(audio_path, language=language)
+        return result["text"].strip()
+
+    def translate_text(self, text: str, source: str, target: str) -> str:
+        """Translate text between English and Japanese."""
+        if source.startswith("en") and target.startswith("ja"):
+            tok, model = self.en_ja_tok, self.en_ja_model
+        elif source.startswith("ja") and target.startswith("en"):
+            tok, model = self.ja_en_tok, self.ja_en_model
+        else:
+            raise ValueError("Unsupported language pair")
+        inputs = tok(text, return_tensors="pt")
+        outputs = model.generate(**inputs)
+        return tok.decode(outputs[0], skip_special_tokens=True)
+
+    def process_audio(self, audio_path: str, source: str, target: str) -> TranslationPair:
+        """Transcribe and translate an audio file."""
+        original = self.transcribe(audio_path, source)
+        translated = self.translate_text(original, source, target)
+        return TranslationPair(original, translated)
+
+
+def color_print(pair: TranslationPair, source: str, target: str) -> None:
+    """Print original and translation with color coding."""
+    src_color = Fore.BLUE if source.startswith("en") else Fore.GREEN
+    tgt_color = Fore.MAGENTA if target.startswith("ja") else Fore.CYAN
+    print(f"{src_color}{pair.text}{Style.RESET_ALL}")
+    print(f"{tgt_color}{pair.translation}{Style.RESET_ALL}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bilingual Live Translator")
+    parser.add_argument("--audio", help="Path to input audio file")
+    parser.add_argument("--text", help="Translate given text instead of audio")
+    parser.add_argument("--source", default="en", help="Source language code")
+    parser.add_argument("--target", default="ja", help="Target language code")
+    args = parser.parse_args()
+
+    if args.audio is None and args.text is None:
+        parser.error("Either --audio or --text must be provided")
+
+    translator = BilingualLiveTranslator()
+
+    if args.audio:
+        pair = translator.process_audio(args.audio, args.source, args.target)
+    else:
+        translation = translator.translate_text(args.text, args.source, args.target)
+        pair = TranslationPair(args.text, translation)
+
+    color_print(pair, args.source, args.target)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+openvino>=2023.0
+openvino-whisper
+optimum[openvino]
+transformers
+soundfile
+sounddevice
+colorama


### PR DESCRIPTION
## Summary
- add prototype script leveraging OpenVINO for speech recognition and translation between English and Japanese
- document usage and dependencies
- provide requirements list for running the prototype

## Testing
- `python -m py_compile app.py`
- `python app.py --text "Hello world" --source en --target ja` *(fails: ModuleNotFoundError: No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_e_68b14ea75f80832e9fef0078a4cf375e