### PR TITLE
Add microphone recording to translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,9 @@ python app.py --audio path/to/audio.wav --source en --target ja
 # python app.py --audio .\\sample_english_audio.wav --source en --target ja
 ```
 
+Record from the microphone and translate to English (speak Japanese):
+```bash
+python app.py --mic --duration 5
+```
+
 Both commands print the original and translated text with colors for easy distinction.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ colorama
 transformers
 sentencepiece
 openai-whisper
+sounddevice


### PR DESCRIPTION
## Summary
- allow recording audio from microphone via `--mic`
- document microphone usage and add sounddevice dependency

## Testing
- `python -m py_compile app.py`
- `python app.py --help`
- `pip install --quiet openai-whisper sounddevice` (fails: Could not find a version that satisfies the requirement openai-whisper)
- `pip install --quiet sounddevice` (fails: Could not find a version that satisfies the requirement sounddevice)


------
https://chatgpt.com/codex/tasks/task_e_68b16f22d1d4832ea776713bb8a140af