### PR TITLE
feat: add real-time word translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,19 @@ python app.py --mic --duration 5
 ```
 
 Both commands print the original and translated text with colors for easy distinction.
+
+## Real-time word-by-word translation (experimental)
+An experimental helper class is provided for streaming translation from the
+microphone.  It splits incoming audio into short chunks, obtains
+word-level timestamps from Whisper and translates each word immediately.
+
+```bash
+python - <<'PY'
+from realtime_translator import RealTimeWordTranslator
+rt = RealTimeWordTranslator()
+rt.stream_from_mic()
+PY
+```
+
+Speak English or Japanese into the microphone and the console will emit the
+recognized word alongside its translation.

--- a/realtime_translator.py
+++ b/realtime_translator.py
@@ -1,0 +1,86 @@
+"""Real-time word-by-word translator using microphone input.
+
+This module provides a small helper class :class:`RealTimeWordTranslator`
+that extends :class:`~app.BilingualLiveTranslator` with the ability to
+listen to the microphone and emit translations for each recognized word in
+near real time.  Audio is processed in short blocks and Whisper's
+``word_timestamps`` option is used to obtain per-word transcription.  Each
+word is then immediately translated using the lightweight Helsinki-NLP
+models already utilised by the project.
+
+The implementation is intentionally simple and intended for prototyping
+purposes.  It runs entirely on the CPU and prints the original/translated
+words to the console as they are produced.
+"""
+
+from __future__ import annotations
+
+import queue
+from typing import Optional
+
+import numpy as np
+import sounddevice as sd
+
+from app import BilingualLiveTranslator
+
+
+class RealTimeWordTranslator(BilingualLiveTranslator):
+    """Translate microphone input word-by-word in real time."""
+
+    def stream_from_mic(
+        self,
+        source: Optional[str] = None,
+        target: Optional[str] = None,
+        block_duration: float = 1.0,
+    ) -> None:
+        """Listen to the microphone and translate audio blocks.
+
+        Parameters
+        ----------
+        source:
+            Source language code (``"en"`` or ``"ja"``).  If ``None`` the
+            language is detected automatically by Whisper.
+        target:
+            Target language code.  If ``None`` the opposite language is used.
+        block_duration:
+            Size of the audio blocks in seconds.  Smaller values yield lower
+            latency at the cost of higher processing overhead.
+        """
+
+        sample_rate = 16000
+        block_frames = int(sample_rate * block_duration)
+        audio_queue: "queue.Queue[np.ndarray]" = queue.Queue()
+
+        def _callback(indata, frames, time_, status):  # pragma: no cover -
+            # Queue audio data for the main thread
+            audio_queue.put(indata.copy())
+
+        print("🎧 Listening... Press Ctrl+C to stop.")
+        with sd.InputStream(
+            callback=_callback, samplerate=sample_rate, channels=1
+        ):
+            buffer = np.zeros((0,), dtype=np.float32)
+            try:
+                while True:
+                    data = audio_queue.get()
+                    buffer = np.concatenate([buffer, data[:, 0]])
+                    if len(buffer) >= block_frames:
+                        segment = buffer[:block_frames]
+                        buffer = buffer[block_frames:]
+                        result = self.whisper_model.transcribe(
+                            segment,
+                            language=source,
+                            fp16=False,
+                            word_timestamps=True,
+                        )
+                        detected = source or result["language"]
+                        tgt = target or ("ja" if detected == "en" else "en")
+                        for seg in result.get("segments", []):
+                            for word in seg.get("words", []):
+                                trans = self.translate_text(
+                                    word["word"], detected, tgt
+                                )
+                                print(f"{word['word']} -> {trans}", flush=True)
+            except KeyboardInterrupt:  # pragma: no cover - manual stop
+                print("\n🛑 Stopped.")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ transformers
 sentencepiece
 openai-whisper
 sounddevice
+numpy


### PR DESCRIPTION
## Summary
- document experimental real-time translator
- add numpy dependency
- stream translation word-by-word from microphone

## Testing
- `python -m py_compile realtime_translator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1724eddf0832eb1d753ff536c6dd3