### PR TITLE
Avoid cuDNN dependency by pinning CPU PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Install dependencies (requires internet access):
 pip install -r requirements.txt
 ```
 
+The `requirements.txt` file pins a CPU-only build of PyTorch. This avoids
+errors such as `Unable to load any of libcudnn...` when CUDA libraries are not
+available on the system.
+
 Translate text:
 ```bash
 python app.py --text "Hello" --source en --target ja

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-torch==2.8.0
+# Use a CPU‑only build of PyTorch to avoid requiring CUDA / cuDNN.
+# The default wheels on PyPI are CPU‑only, so pin to a recent stable version.
+torch==2.3.1
 colorama
 transformers
 sentencepiece

--- a/simple_realtime_translator.py
+++ b/simple_realtime_translator.py
@@ -9,7 +9,8 @@ asr_model = WhisperModel("medium", device="cpu")  # GPUがあれば "cuda"
 
 # 翻訳モデル (英語→日本語)
 #translator = pipeline("translation", model="Helsinki-NLP/opus-mt-en-jap")
-translator = pipeline("translation", model="Helsinki-NLP/opus-mt-jap-en")
+# Run translation on CPU to avoid loading GPU libraries when CUDA is unavailable.
+translator = pipeline("translation", model="Helsinki-NLP/opus-mt-jap-en", device=-1)
 
 # 音声設定
 SAMPLE_RATE = 16000


### PR DESCRIPTION
## Summary
- use CPU-only PyTorch to prevent cuDNN load failures
- run translation pipeline on CPU to avoid CUDA library usage
- document CPU requirement and cuDNN error avoidance in README

## Testing
- `python -m py_compile simple_realtime_translator.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b190ca905c832eb7fb3113aae6c14a