### PR TITLE
Swap panels and reduce silence threshold

### DIFF
--- a/simple_realtime_translator.py
+++ b/simple_realtime_translator.py
@@ -41,7 +41,7 @@ CHANNELS = 1
 RECORD_SECONDS = 3
 
 # Silence detection threshold (peak amplitude)
-silence_threshold = 500
+silence_threshold = 100
 
 # Debug settings
 DEBUG_MODE = True

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,18 +19,19 @@
             max-width: 1200px;
             margin: 0 auto;
             display: grid;
-            grid-template-columns: 1fr 400px;
+            grid-template-columns: 400px 1fr;
             gap: 20px;
         }
-        
+
         .main-panel {
             background: rgba(255, 255, 255, 0.95);
             border-radius: 15px;
             padding: 30px;
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
             backdrop-filter: blur(10px);
+            order: 2;
         }
-        
+
         .debug-panel {
             background: rgba(0, 0, 0, 0.85);
             border-radius: 15px;
@@ -40,6 +41,7 @@
             font-size: 12px;
             max-height: 80vh;
             overflow-y: auto;
+            order: 1;
         }
         
         h1 {
@@ -101,6 +103,8 @@
             margin-bottom: 20px;
             box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
             min-height: 120px;
+            max-height: 70vh;
+            overflow-y: auto;
         }
         
         .subtitle-item {
@@ -248,7 +252,7 @@
 
                 <div class="control-group">
                     <label for="silenceThreshold">無音しきい値:</label>
-                    <input type="number" id="silenceThreshold" value="500" min="0" max="1000" step="10">
+                    <input type="number" id="silenceThreshold" value="100" min="0" max="1000" step="10">
                 </div>
 
                 <div class="control-group">
@@ -381,11 +385,6 @@
             `;
             
             subtitlesDiv.appendChild(subtitleItem);
-            
-            // Keep only last 5 subtitles
-            while (subtitlesDiv.children.length > 6) { // +1 for initial message
-                subtitlesDiv.removeChild(subtitlesDiv.children[1]); // Skip first child (initial message)
-            }
             
             // Scroll to bottom
             subtitlesDiv.scrollTop = subtitlesDiv.scrollHeight;


### PR DESCRIPTION
## Summary
- Swap layout so debug panel appears on the left and translation panel on the right
- Enable scrolling of subtitle history and keep all entries
- Lower default silence detection threshold to 100

## Testing
- `python -m py_compile simple_realtime_translator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3daa7d038832e9d44d5d5bc65d3a0