### PR TITLE
Asynchronous Whisper inference with updated translation models

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,12 +49,12 @@ class BilingualLiveTranslator:
         self.translators = {
             ("en", "ja"): pipeline(
                 "translation",
-                model="Helsinki-NLP/opus-mt-en-jap",
+                model="Helsinki-NLP/opus-mt-en-ja",
                 device=-1  # Use CPU
             ),
             ("ja", "en"): pipeline(
                 "translation",
-                model="Helsinki-NLP/opus-mt-jap-en",
+                model="Helsinki-NLP/opus-mt-ja-en",
                 device=-1  # Use CPU
             ),
         }


### PR DESCRIPTION
## Summary
- decouple audio capture from Whisper processing using a queue for parallel recording and transcription
- fix translation pipeline names to use `Helsinki-NLP/opus-mt-ja-en` and `Helsinki-NLP/opus-mt-en-ja`

## Testing
- `python -m py_compile app.py simple_realtime_translator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3e1687888832ea6e1bc66b2a31575