### PR TITLE
Process audio every second and show subtitles

### DIFF
--- a/simple_realtime_translator.py
+++ b/simple_realtime_translator.py
@@ -39,7 +39,8 @@ translation_direction = 'ja-en'
 # Audio config
 FS = 16000
 CHANNELS = 1
-RECORD_SECONDS = 3
+# Record shorter clips so speech recognition and translation run every second
+RECORD_SECONDS = 1
 
 # Silence detection threshold (peak amplitude)
 silence_threshold = 10

--- a/templates/index.html
+++ b/templates/index.html
@@ -378,7 +378,8 @@
 
         function displaySubtitle(original, translated) {
             const subtitlesDiv = document.getElementById('subtitles');
-            if (subtitlesDiv.firstChild && subtitlesDiv.firstChild.tagName === 'P') {
+            // Remove placeholder message once real subtitles arrive
+            if (subtitlesDiv.firstElementChild && subtitlesDiv.firstElementChild.tagName === 'P') {
                 subtitlesDiv.innerHTML = '';
             }
             const subtitleItem = document.createElement('div');


### PR DESCRIPTION
## Summary
- Record 1-second audio clips so speech recognition & translation run each second
- Clean up placeholder subtitles when real translations arrive

## Testing
- `python -m py_compile simple_realtime_translator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3e94ee360832eb0b6063b94b2172b