### PR TITLE
Add FastAPI translation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ python app.py --mic --duration 5
 
 Both commands print the original and translated text with colors for easy distinction.
 
+## FastAPI server
+A minimal web API built with FastAPI is provided in `fastapi_app.py`.
+
+Start the server:
+
+```bash
+uvicorn fastapi_app:app --reload
+```
+
+Translate an audio file by sending a multipart request:
+
+```bash
+curl -F "file=@sample_english_audio.wav" -F "source=en" -F "target=ja" \
+  http://localhost:8000/translate/audio
+```
+
+Translate plain text with JSON:
+
+```bash
+curl -X POST http://localhost:8000/translate/text \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello","source":"en","target":"ja"}'
+```
+
 ## Real-time word-by-word translation (experimental)
 An experimental helper class is provided for streaming translation from the
 microphone.  It splits incoming audio into short chunks, obtains

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1,0 +1,65 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from pydantic import BaseModel
+from typing import Optional
+import tempfile
+import shutil
+import os
+
+from app import BilingualLiveTranslator
+
+app = FastAPI(title="Bilingual Live Translator")
+
+translator = BilingualLiveTranslator()
+
+
+class TextTranslationRequest(BaseModel):
+    text: str
+    source: str
+    target: str
+
+
+@app.post("/translate/audio")
+async def translate_audio(
+    file: UploadFile = File(...),
+    source: Optional[str] = Form(None),
+    target: Optional[str] = Form(None),
+):
+    """Transcribe and translate an uploaded audio file.
+
+    Parameters
+    ----------
+    file: UploadFile
+        Audio file to process.
+    source: str, optional
+        Source language code ("en" or "ja"). If omitted, auto detect.
+    target: str, optional
+        Target language code. If omitted, automatically pick the opposite
+        language of the detected source.
+    """
+    suffix = os.path.splitext(file.filename)[1]
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        shutil.copyfileobj(file.file, tmp)
+        tmp_path = tmp.name
+
+    try:
+        pair = translator.process_audio(tmp_path, source, target)
+    finally:
+        os.remove(tmp_path)
+
+    return {
+        "original": pair.text,
+        "translation": pair.translation,
+        "detected_language": pair.language_detected,
+    }
+
+
+@app.post("/translate/text")
+async def translate_text(req: TextTranslationRequest):
+    """Translate plain text between English and Japanese."""
+    translation = translator.translate_text(req.text, req.source, req.target)
+    return {"original": req.text, "translation": translation}
+
+
+@app.get("/")
+async def root():
+    return {"message": "Bilingual Live Translator API"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ sounddevice
 numpy
 nvidia-cublas-cu12
 nvidia-cudnn-cu12==9.*
+fastapi
+uvicorn
+python-multipart


### PR DESCRIPTION
## Summary
- create FastAPI server providing text and audio translation endpoints
- document FastAPI usage and add dependencies

## Testing
- `python -m py_compile fastapi_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b40a24a2e4832eacb7e59d43d0a6ed