### PR TITLE
docs: use plain HTML frontend

### DIFF
--- a/dock/architecture.md
+++ b/dock/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 ## 技術スタック
-- フロントエンド: React + Tailwind CSS
+- フロントエンド: シンプルなHTML（フレームワークなし）
 - バックエンド: FastAPI + WebSocket
 - データベース: SQLite
 - 認証: APIキー認証（FastAPI Security）
@@ -11,7 +11,7 @@
 ## システム構成図
 ```mermaid
 graph LR
-    A[User Mic] --> B[React App]
+    A[User Mic] --> B[HTML Page]
     B -- audio stream --> C(FastAPI)
     C --> D[faster-whisper]
     D --> C
@@ -22,8 +22,7 @@ graph LR
 ```
 
 ## 選択理由
-- React: リアルタイム字幕表示や色分け表示など動的UIに対応しやすく、クロスプラットフォームの要件にも合致
-- Tailwind CSS: 少ない記述でデザイン調整が可能で、個人開発でも素早くスタイルを整えられるため
+- HTML: フレームワークを使わずに最小限の実装で済ませられ、学習コストが低い
 - FastAPI: Python製で軽量・非同期処理に強く、リアルタイム処理に向いている
 - WebSocket: 認識～翻訳～表示までのリアルタイム性を確保するための双方向通信
 - SQLite: ファイルベースでセットアップが簡単、翻訳履歴保存の要件に十分対応


### PR DESCRIPTION
## Summary
- describe the frontend as a lightweight HTML page without frameworks
- adjust system diagram and rationale to remove React and Tailwind

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b523b286d4832e9dded982e7131562