### PR TITLE
docs: replace DeepL references with Helsinki-NLP model

### DIFF
--- a/Requirment_Definition.md
+++ b/Requirment_Definition.md
@@ -58,7 +58,7 @@
 
 ## 5. 技術要件
 - **音声認識**：OpenAI Whisper / Google Speech-to-Text / Azure Speech SDK。  
-- **翻訳**：OpenAI GPT-4o / DeepL API / Google Translate API。  
+- **翻訳**：OpenAI GPT-4o / Helsinki-NLP公開モデル / Google Translate API。
 - **フロントエンド**：Electron（PC向け）または Flutter（クロスプラットフォーム）。  
 - **バックエンド**：Python (FastAPI, Flask) または Node.js。  
 - **表示更新**：WebSocketによるリアルタイム更新。  

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 - フロントエンド: シンプルなHTML（フレームワークなし）
 - バックエンド: FastAPI + WebSocket
 - インフラ: Docker
-- その他: faster-whisper + DeepL API Free
+- その他: faster-whisper + Helsinki-NLP翻訳モデル
 
 ## システム構成図
 ```mermaid
@@ -15,7 +15,7 @@ graph LR
     B -- audio stream --> C(FastAPI)
     C --> D[faster-whisper]
     D --> C
-    C --> E[DeepL API]
+    C --> E[Helsinki-NLP翻訳モデル]
     E --> C
     C -- subtitle via WebSocket --> B
 ```
@@ -26,4 +26,4 @@ graph LR
 - WebSocket: 認識～翻訳～表示までのリアルタイム性を確保するための双方向通信
 - Docker: 開発とデモ実行時に同一環境を構築し、運用を簡素化する
 - faster-whisper: CPUでも動作するオープンソースSTTで、無料かつ高精度
-- DeepL API Free: 高精度翻訳を無料枠で利用でき、コストを抑えつつ要件を満たせる
+- Helsinki-NLP翻訳モデル: 公開されているオープンソース翻訳モデルを利用することで、費用をかけずに要件を満たせる


### PR DESCRIPTION
## Summary
- use Helsinki-NLP translation models instead of DeepL in architecture and requirements docs
## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5295aa5a0832eb1d64d3423f05a65