### PR TITLE
Align frontend buttons on a single line

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -55,7 +55,7 @@
             align-items: center;
             gap: 15px;
             margin-bottom: 10px;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
         }
 
         .controls-header label {
@@ -69,7 +69,7 @@
             justify-content: center;
             gap: 15px;
             margin-bottom: 30px;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
         }
         
         .control-group {
@@ -358,17 +358,20 @@
             }
             
             .controls {
-                flex-direction: column;
+                flex-direction: row;
+                flex-wrap: nowrap;
                 gap: 10px;
+                overflow-x: auto;
             }
-            
+
             .control-group {
-                width: 100%;
+                flex: 0 0 auto;
+                width: auto;
             }
-            
+
             select, button, input[type="number"] {
-                width: 100%;
-                max-width: 300px;
+                width: auto;
+                max-width: none;
             }
         }
         


### PR DESCRIPTION
## Summary
- Prevent buttons from wrapping by setting `flex-wrap: nowrap` on control containers.
- Update mobile styles so control groups remain in a horizontal row with horizontal scrolling.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5819bf3c0832ea3d0d7b54a7f4e16